### PR TITLE
Deployment Docs for Capistrano Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository is a place for documents detailing workflows, architecture, usef
 - [Code Snippets for File / Folder Management](file-management.md)
 - [Solr Ingest Scripts](solr-ingest.md)
 - [Using the FDA (DSpace) API](fda-api.md)
-
+- [Deploying SDR](deployment.md)
 #### Additional Resources
 
 Some documentation is listed below. These documents may contain some outdated claims, so always be conscious of the dates (and defer to the materials listed above in case of conflicting information):

--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,19 @@
+# Deploying SDR Services (using `capistrano`)
+
+Using `capistrano` to deploy SDR is a simple process you can perform from your local environment. 
+You will need the following:
+
+- A local clone of the SDR repository
+- the SSH key for the staging/production servers (See DevOps for this key)
+- connection to to the NYU VPN (if off-campus)
+
+
+## Deployment Commands
+
+Deploying to `staging` is this command:
+
+`cap staging deploy`
+
+Deploying to `production` is this command:
+
+`cap production deploy`


### PR DESCRIPTION
We're using `capistrano` now to deploy SDR. These are the docs for it. 